### PR TITLE
Every project needs a readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 - Experiment with HTML, CSS and design patterns that I have not implemented before.
 - Showcase my work for friends, colleagues and potential collaborators and employers.
 - Learn more about building advanced static sites with Jekyll.
-- Initially, design and implement entirely by myself, with feedback from others.
+- Initially, design and implement entirely by myself, with later feedback from others.
 
 ## Principles
 
@@ -16,6 +16,7 @@
 - Pattern second
 - High performance
 - Minimalism
+- Progressive enhancement
 - Respect for users and their devices
 - Empathy in content, design and tone
 
@@ -23,9 +24,11 @@
 
 - Jekyll for building
 - Amazon S3 for deploying and hosting
+- TypeKit for fonts – using three weights of [Ratio by p.s.type](http://cargocollective.com/pstype/Ratio)
 - MapBox for maps
 - Responsive images using `srcset` HTML specification
 - No templates, pre-processors or boilerplate
+- As little JavaScript as possible
 
 ## Requirements
 


### PR DESCRIPTION
Why do we use the prescriptive term “readme” anyway? It sounds like a relic of a very different approach to writing for users of software. GitHub demands it, though.
