### PR TITLE
Upgrade to Jekyll 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ _site
 .DS_Store
 .bundle/
 .sass-cache
+.jekyll-metadata
 all.min.js

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,11 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '>= 2.5'
-gem 'jekyll-archives'
+gem 'jekyll', '~> 3.0'
+gem 'jekyll-archives', github: 'jekyll/jekyll-archives'
 
-gem 'kramdown', '= 1.5.0', :git => 'https://github.com/opattison/kramdown.git', :branch => 'master'
+gem 'kramdown'
 gem 'rouge'
 gem 'sass'
-gem 'octopress-autoprefixer'
 
 gem 's3_website'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,110 +1,66 @@
 GIT
-  remote: https://github.com/opattison/kramdown.git
-  revision: 1e6e95894853601bb00e470b5edf5992f0daff84
-  branch: master
+  remote: git://github.com/jekyll/jekyll-archives.git
+  revision: c9eac2c729bb3f8e3821bbaf529bd53cb5e7da66
   specs:
-    kramdown (1.5.0)
+    jekyll-archives (2.0.0)
+      jekyll (>= 2.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    autoprefixer-rails (2.2.0.20140804)
-      execjs
-    blankslate (2.1.2.4)
-    celluloid (0.16.0)
-      timers (~> 4.0.0)
-    classifier-reborn (2.0.3)
-      fast-stemmer (~> 1.0)
-    coffee-script (2.3.0)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.9.1)
     colorator (0.1)
     colored (1.2)
     configure-s3-website (1.7.1)
       deep_merge (= 1.0.0)
     deep_merge (1.0.0)
     dotenv (1.0.2)
-    execjs (2.4.0)
-    exifr (1.2.1)
-    fast-stemmer (1.0.2)
-    ffi (1.9.6)
+    exifr (1.2.3.1)
+    ffi (1.9.10)
     fspath (2.1.1)
-    hitimes (1.2.2)
-    image_optim (0.20.2)
-      exifr (~> 1.1, >= 1.1.3)
+    image_optim (0.21.0)
+      exifr (~> 1.2, >= 1.2.2)
       fspath (~> 2.1)
       image_size (~> 1.3)
       in_threads (~> 1.3)
       progress (~> 3.0, >= 3.0.1)
-    image_optim_pack (0.2.1.20150305)
+    image_optim_pack (0.2.1.20151012)
       fspath (~> 2.1)
       image_optim (~> 0.19)
     image_size (1.4.1)
     in_threads (1.3.1)
-    jekyll (2.5.3)
-      classifier-reborn (~> 2.0)
+    jekyll (3.0.0)
       colorator (~> 0.1)
-      jekyll-coffeescript (~> 1.0)
-      jekyll-gist (~> 1.0)
-      jekyll-paginate (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
       kramdown (~> 1.3)
-      liquid (~> 2.6.1)
+      liquid (~> 3.0)
       mercenary (~> 0.3.3)
-      pygments.rb (~> 0.6.0)
-      redcarpet (~> 3.1)
+      rouge (~> 1.7)
       safe_yaml (~> 1.0)
-      toml (~> 0.1.0)
-    jekyll-archives (2.0.0)
-      jekyll (~> 2.4)
-    jekyll-coffeescript (1.0.1)
-      coffee-script (~> 2.2)
-    jekyll-gist (1.1.0)
-    jekyll-paginate (1.1.0)
     jekyll-sass-converter (1.3.0)
       sass (~> 3.2)
-    jekyll-watch (1.2.1)
-      listen (~> 2.7)
-    liquid (2.6.2)
-    listen (2.8.5)
-      celluloid (>= 0.15.2)
+    jekyll-watch (1.3.0)
+      listen (~> 3.0)
+    kramdown (1.9.0)
+    liquid (3.0.6)
+    listen (3.0.3)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     mercenary (0.3.5)
-    octopress-autoprefixer (1.0.0)
-      autoprefixer-rails (~> 2.2)
-      jekyll (~> 2.0)
-      octopress-hooks (~> 2.0)
-    octopress-hooks (2.6.0)
-      jekyll (~> 2.0)
-    parslet (1.5.0)
-      blankslate (~> 2.0)
-    posix-spawn (0.3.10)
     progress (3.1.0)
-    pygments.rb (0.6.2)
-      posix-spawn (~> 0.3.6)
-      yajl-ruby (~> 1.2.0)
     rake (10.4.2)
-    rb-fsevent (0.9.4)
+    rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    redcarpet (3.2.2)
-    rouge (1.8.0)
-    s3_website (2.8.4)
+    rouge (1.10.1)
+    s3_website (2.12.2)
       colored (= 1.2)
       configure-s3-website (= 1.7.1)
       dotenv (~> 1.0)
       thor (~> 0.18)
     safe_yaml (1.0.4)
-    sass (3.4.13)
+    sass (3.4.19)
     thor (0.19.1)
-    timers (4.0.1)
-      hitimes
-    toml (0.1.2)
-      parslet (~> 1.5.0)
-    yajl-ruby (1.2.1)
 
 PLATFORMS
   ruby
@@ -112,11 +68,13 @@ PLATFORMS
 DEPENDENCIES
   image_optim
   image_optim_pack
-  jekyll (>= 2.5)
-  jekyll-archives
-  kramdown (= 1.5.0)!
-  octopress-autoprefixer
+  jekyll (~> 3.0)
+  jekyll-archives!
+  kramdown
   rake
   rouge
   s3_website
   sass
+
+BUNDLED WITH
+   1.10.6

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ local_site     = "_site"
 ## "rake serve"
 desc "custom Jekyll serve for local development"
 task :serve do
-  system "jekyll serve -H 10.0.0.13 --config _config.yml,_config-dev.yml"
+  system "jekyll serve --config _config.yml,_config-dev.yml"
 end
 
 ## "rake optimize" to optimize a folder of images in ImageOptim-CLI

--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,6 @@ collections:
 gems:
   - jekyll-archives
   - sass
-  - octopress-autoprefixer
 
 ## Markdown configuration
 markdown: kramdown

--- a/_config.yml
+++ b/_config.yml
@@ -41,9 +41,10 @@ gems:
 
 ## Markdown configuration
 markdown: kramdown
+highlighter: rouge
 kramdown:
   input: GFM
-  syntax_highlighter: rouge
+  footnote_backlink: '&#8638;'
 
 ## Permalink configuration
 permalink: /:year/:month/:title/

--- a/_patterns/ancillary.html
+++ b/_patterns/ancillary.html
@@ -3,16 +3,14 @@ title: .ancillary [aside]
 use: 'For content that is related to the main body but not necessarily as important – supporting the main story without being directly a part of it.'
 spec: 'Lower contrast light background that connects seamlessly with the body background, pushed slightly or significantly to the right of body text on larger layouts.'
 type: markdown
+include_markdown: >
+  # Ancillary content
+
+  Using a `capture` tag with Liquid allows one to encode Markdown text into an HTML block. One could use a Ruby plugin for Jekyll to process it, but that may be less effective.
 ---
 
-{% capture ancillary %}
-# Ancillary content
-
-Using a `capture` tag with Liquid allows one to encode Markdown text into an HTML block. One could use a Ruby plugin for Jekyll to process it, but that may be less effective.
-{% endcapture %}
-
 <aside class="ancillary">
-{{ ancillary | markdownify }}
+{{ page.include_markdown | markdownify }}
 </aside>
 
 Content flows after or around the `<aside>` block. The `.ancillary` block should be used {{ page.use | downcase }} This paragraph represents the layout and style of main body content.

--- a/readme.md
+++ b/readme.md
@@ -36,8 +36,8 @@
 
 ### Configuration
 
-- [Jekyll](http://jekyllrb.com) >2.5.3
-- [jekyll-archives](https://github.com/jekyll/jekyll-archives) >2.0.0
+- [Jekyll](http://jekyllrb.com) >3.0
+- [jekyll-archives](https://github.com/jekyll/jekyll-archives) >2.0.0 (using master branch on GitHub)
 - [rouge](https://github.com/jneen/rouge) >1.7.4
 - [sass](https://github.com/sass/sass) >3.4.12
 - [uglifier](https://github.com/lautis/uglifier) >2.7.1


### PR DESCRIPTION
- Ensure that builds are consistent with Jekyll 2.5.3
- Check compatibility for the currently essential jekyll-archives