### PR TITLE
Color re-thinking

### DIFF
--- a/_data/shade.yml
+++ b/_data/shade.yml
@@ -2,32 +2,32 @@
     hsl: 'hsl(204, 10%, 12%)'
     hex: '#1c1f22'
   - name: gray00
-    hsl: 'hsl(204, 10%, 18%)'
-    hex: '#292f32'
+    hsl: 'hsl(204, 10%, 16%)'
+    hex: '#252a2d'
   - name: gray01
-    hsl: 'hsl(204, 10%, 24%)'
-    hex: '#373e43'
+    hsl: 'hsl(204, 10%, 21%)'
+    hex: '#30373b'
   - name: gray02
-    hsl: 'hsl(204, 10%, 32%)'
-    hex: '#49535a'
+    hsl: 'hsl(204, 10%, 25%)'
+    hex: '#394146'
   - name: gray03
-    hsl: 'hsl(204, 10%, 40%)'
-    hex: '#5c6870'
+    hsl: 'hsl(204, 10%, 30%)'
+    hex: '#454e54'
   - name: gray04
-    hsl: 'hsl(204, 10%, 72%)'
-    hex: '#b0b9bf'
+    hsl: 'hsl(204, 10%, 76%)'
+    hex: '#bcc3c8'
   - name: gray05
-    hsl: 'hsl(204, 10%, 80%)'
-    hex: '#c7cdd1'
+    hsl: 'hsl(204, 10%, 81%)'
+    hex: '#c9cfd2'
   - name: gray06
-    hsl: 'hsl(204, 10%, 88%)'
-    hex: '#dde1e3'
+    hsl: 'hsl(204, 10%, 85%)'
+    hex: '#d5dadd'
   - name: gray07
-    hsl: 'hsl(204, 10%, 92%)'
-    hex: '#e9ebed'
+    hsl: 'hsl(204, 10%, 90%)'
+    hex: '#e3e6e8'
   - name: white
     hsl: 'hsl(204, 10%, 95%)'
     hex: '#f1f3f4'
   - name: whiter
-    hsl: 'hsl(204, 10%, 97%)'
+    hsl: 'hsl(180, 7%, 97%)'
     hex: '#f7f8f8'

--- a/_data/theme_paper.yml
+++ b/_data/theme_paper.yml
@@ -1,30 +1,30 @@
   - name: black
-    hsl: 'hsl(0, 0%, 12%)'
-    hex: '#1f1f1f'
+    hsl: 'hsl(58, 10%, 12%)'
+    hex: '#22211c'
   - name: gray00
-    hsl: 'hsl(0, 0%, 16%)'
-    hex: '#292929'
+    hsl: 'hsl(58, 10%, 16%)'
+    hex: '#2d2d25'
   - name: gray01
-    hsl: 'hsl(0, 0%, 21%)'
-    hex: '#363636'
+    hsl: 'hsl(58, 10%, 21%)'
+    hex: '#3b3b30'
   - name: gray02
-    hsl: 'hsl(0, 0%, 25%)'
-    hex: '#404040'
+    hsl: 'hsl(58, 10%, 25%)'
+    hex: '#464639'
   - name: gray03
-    hsl: 'hsl(0, 0%, 30%)'
-    hex: '#4d4d4d'
+    hsl: 'hsl(58, 10%, 30%)'
+    hex: '#545445'
   - name: gray04
-    hsl: 'hsl(0, 0%, 76%)'
-    hex: '#c2c2c2'
+    hsl: 'hsl(58, 10%, 76%)'
+    hex: '#c8c8bc'
   - name: gray05
-    hsl: 'hsl(0, 0%, 81%)'
-    hex: '#cfcfcf'
+    hsl: 'hsl(58, 10%, 81%)'
+    hex: '#d2d2c9'
   - name: gray06
-    hsl: 'hsl(0, 0%, 85%)'
-    hex: '#d9d9d9'
+    hsl: 'hsl(58, 10%, 85%)'
+    hex: '#dddcd5'
   - name: gray07
-    hsl: 'hsl(0, 0%, 90%)'
-    hex: '#e6e6e6'
+    hsl: 'hsl(58, 10%, 90%)'
+    hex: '#e8e8e3'
   - name: white
     hsl: 'hsl(58, 40%, 96%)'
     hex: '#f9f9f1'

--- a/_data/theme_paper.yml
+++ b/_data/theme_paper.yml
@@ -1,0 +1,36 @@
+  - name: black
+    hsl: 'hsl(0, 0%, 12%)'
+    hex: '#1f1f1f'
+  - name: gray00
+    hsl: 'hsl(0, 0%, 18%)'
+    hex: '#2e2e2e'
+  - name: gray01
+    hsl: 'hsl(0, 0%, 24%)'
+    hex: '#3d3d3d'
+  - name: gray02
+    hsl: 'hsl(0, 0%, 32%)'
+    hex: '#525252'
+  - name: gray03
+    hsl: 'hsl(0, 0%, 40%)'
+    hex: '#666666'
+  - name: gray04
+    hsl: 'hsl(0, 0%, 72%)'
+    hex: '#b8b8b8'
+  - name: gray05
+    hsl: 'hsl(0, 0%, 80%)'
+    hex: '#cccccc'
+  - name: gray06
+    hsl: 'hsl(0, 0%, 88%)'
+    hex: '#e0e0e0'
+  - name: gray07
+    hsl: 'hsl(0, 0%, 92%)'
+    hex: '#ebebeb'
+  - name: white
+    hsl: 'hsl(58, 40%, 95%)'
+    hex: '#f7f7ed'
+  - name: whiter
+    hsl: 'hsl(58, 40%, 97%)'
+    hex: '#fafaf4'
+  - name: tan
+    hsl: 'hsl(58, 40%, 92%)'
+    hex: '#f4f3e2'

--- a/_data/theme_paper.yml
+++ b/_data/theme_paper.yml
@@ -2,35 +2,35 @@
     hsl: 'hsl(0, 0%, 12%)'
     hex: '#1f1f1f'
   - name: gray00
-    hsl: 'hsl(0, 0%, 18%)'
-    hex: '#2e2e2e'
+    hsl: 'hsl(0, 0%, 16%)'
+    hex: '#292929'
   - name: gray01
-    hsl: 'hsl(0, 0%, 24%)'
-    hex: '#3d3d3d'
+    hsl: 'hsl(0, 0%, 21%)'
+    hex: '#363636'
   - name: gray02
-    hsl: 'hsl(0, 0%, 32%)'
-    hex: '#525252'
+    hsl: 'hsl(0, 0%, 25%)'
+    hex: '#404040'
   - name: gray03
-    hsl: 'hsl(0, 0%, 40%)'
-    hex: '#666666'
+    hsl: 'hsl(0, 0%, 30%)'
+    hex: '#4d4d4d'
   - name: gray04
-    hsl: 'hsl(0, 0%, 72%)'
-    hex: '#b8b8b8'
+    hsl: 'hsl(0, 0%, 76%)'
+    hex: '#c2c2c2'
   - name: gray05
-    hsl: 'hsl(0, 0%, 80%)'
-    hex: '#cccccc'
+    hsl: 'hsl(0, 0%, 81%)'
+    hex: '#cfcfcf'
   - name: gray06
-    hsl: 'hsl(0, 0%, 88%)'
-    hex: '#e0e0e0'
+    hsl: 'hsl(0, 0%, 85%)'
+    hex: '#d9d9d9'
   - name: gray07
-    hsl: 'hsl(0, 0%, 92%)'
-    hex: '#ebebeb'
+    hsl: 'hsl(0, 0%, 90%)'
+    hex: '#e6e6e6'
   - name: white
-    hsl: 'hsl(58, 40%, 95%)'
-    hex: '#f7f7ed'
+    hsl: 'hsl(58, 40%, 96%)'
+    hex: '#f9f9f1'
   - name: whiter
-    hsl: 'hsl(58, 40%, 97%)'
-    hex: '#fafaf4'
+    hsl: 'hsl(58, 40%, 98%)'
+    hex: '#fcfcf9'
   - name: tan
-    hsl: 'hsl(58, 40%, 92%)'
-    hex: '#f4f3e2'
+    hsl: 'hsl(58, 40%, 93%)'
+    hex: '#f4f4e6'

--- a/_includes/head/styles.html
+++ b/_includes/head/styles.html
@@ -3,6 +3,9 @@
 {% if page.theme == 'dark' or page.layout contains 'archive' %}
   <link rel="stylesheet" href="{{ site.style_url }}/dark.css">
 {% endif %}
+{% if page.theme == 'paper' %}
+  <link rel="stylesheet" href="{{ site.style_url }}/paper.css">
+{% endif %}
 {% if page.layout == 'edgeless' %}
   <link rel="stylesheet" href="{{ site.style_url }}/edgeless.css">
 {% endif %}

--- a/_layouts/edgeless.html
+++ b/_layouts/edgeless.html
@@ -8,6 +8,7 @@
 
   <article id="maincontent" class="h-entry page" role="main">
 
+    {% include block/hero.html %}
     {% include block/page-title.html %}
 
     <div class="e-content content">

--- a/_pages/patterns.md
+++ b/_pages/patterns.md
@@ -15,13 +15,8 @@ image:
 
 ---
 
-{% capture intro %}
 This is a collection of all of the patterns on [olivermak.es]({{ site.url }}), organized by [color](/patterns/color/), [text](/patterns/text/), modular [components](/patterns/component/), and other [interface](/patterns/interface/) elements. These patterns serve as living documentation for this site’s present design. They also prescribe use and specification for every element on the site. The source for these patterns is [on GitHub]({{ site.source_url.repo }}).
-{% endcapture %}
-
-<div class="content" style="background-color: inherit;">
-{{ intro | markdownify }}
-</div>
+{:.content--pattern}
 
 <div class="pattern-index">
 {% assign items = site.patterns-categories %}

--- a/_patterns-categories/color.md
+++ b/_patterns-categories/color.md
@@ -40,3 +40,17 @@ image:
 {% include block/pattern--swatch.html %}
 {% endfor %}
 </ul>
+
+---
+
+## `paper` theme
+
+This is used on several pages, reusing all of the colors above but replacing the shades.
+{:.content--pattern}
+
+<ul class="grid--swatches no-bullets">
+{% assign swatches = site.data.theme_paper %}
+{% for swatch in swatches %}
+{% include block/pattern--swatch.html %}
+{% endfor %}
+</ul>

--- a/_posts/2012-03-06-casey-trees-redesign.md
+++ b/_posts/2012-03-06-casey-trees-redesign.md
@@ -1,6 +1,7 @@
 ---
 title: 'Responsive redesign for Casey Trees'
 layout: singel
+theme: paper
 category: 'projects'
 tags:
   - 'design'

--- a/_posts/2013-09-26-casey-trees-membership.md
+++ b/_posts/2013-09-26-casey-trees-membership.md
@@ -1,6 +1,7 @@
 ---
 title: 'Membership design for Casey Trees'
 layout: singel
+theme: paper
 option:
   - code
 category: 'projects'

--- a/_posts/2015-10-24-pine-orchard-typography.md
+++ b/_posts/2015-10-24-pine-orchard-typography.md
@@ -1,6 +1,7 @@
 ---
 title: 'Pine Orchard Prints typographic identity'
 layout: edgeless
+theme: paper
 option:
   - minor
 category: 'projects'

--- a/_posts/2015-10-24-pine-orchard-typography.md
+++ b/_posts/2015-10-24-pine-orchard-typography.md
@@ -9,7 +9,7 @@ tags:
   - 'design'
   - 'typography'
   - 'web'
-updated: 2016-02-09 01:01
+updated: 2016-03-25 09:13
 drafted: 2016-01-26 23:22
 unique_id: 2015-10-24:pine-orchard-typography
 description: 'Logotype and typography for a small online retail shop.'
@@ -119,6 +119,11 @@ For a small shop, memorable and appropriate typography effectively served the bu
   {% include block/figcaption--image.html %}
 </figure>
 
+---
+
+## Read more about the entire project
+
+{% include block/project--satellite.html id="2015-01-29:pine-orchard-site" %}
 
 [^1]: Cardo is available for free through Google Fonts, but I chose to serve it through an Adobe TypeKit subscription because of their superior OpenType support.
 [^2]: Even Safari 9.0 for OS X and iOS does not have support for it at the time of this writing, but 9.1 will! Following the principle of progressive enhancement and not relying too heavily on the small caps style meant that I could get away without optimizing for Safari in this case. The logotype, however, uses SVG outlines to ensure that it renders consistently across browsers.

--- a/_posts/2016-03-16-consider-jekyll.md
+++ b/_posts/2016-03-16-consider-jekyll.md
@@ -1,6 +1,6 @@
 ---
 title: 'Consider Jekyll'
-layout: singel
+layout: edgeless
 option:
   - hero
 category: 'writing'

--- a/_posts/2016-03-17-jekyll-cost.md
+++ b/_posts/2016-03-17-jekyll-cost.md
@@ -1,6 +1,6 @@
 ---
 title: 'Jekyll’s cost'
-layout: singel
+layout: edgeless
 category: 'writing'
 tags:
   - 'jekyll'

--- a/resources/edgeless.scss
+++ b/resources/edgeless.scss
@@ -23,6 +23,14 @@
   }
 }
 
+.hero {
+  max-width: 100%;
+
+  @include min-width(l01) {
+    margin-bottom: 4em;
+  }
+}
+
 .page-title {
 
   @include min-width(l01) {

--- a/resources/paper.scss
+++ b/resources/paper.scss
@@ -1,0 +1,4 @@
+---
+---
+@import 'helpers';
+@import 'theme/paper';

--- a/resources/patterns.scss
+++ b/resources/patterns.scss
@@ -164,6 +164,21 @@
   overflow: hidden;
 }
 
+.content--pattern {
+  background-color: inherit;
+  margin: 1em auto 0;
+  padding: 2em 1em;
+
+  @include min-width(m02) {
+    @include width-max(m02);
+    padding: 1em 0;
+  }
+
+  @include min-width(l01) {
+    font-size: 1.25em;
+  }
+}
+
 .item--pattern {
   flex: 0 0 calc(100% - 2em);
   margin: 1em auto 0;

--- a/resources/scss/_fundamental.scss
+++ b/resources/scss/_fundamental.scss
@@ -188,20 +188,6 @@ blockquote footer {
   text-align: right;
 }
 
-// Footnotes
-sup[id] {
-  margin: 0;
-  top: 0;
-}
-
-sup[id] a {
-  border: solid 1px;
-  border-radius: .125em;
-  font-weight: $weight-medium;
-  margin-right: .125em;
-  padding: 0 .25em;
-}
-
 // Figcaptions
 figcaption {
   margin: 0 0 .5em;

--- a/resources/scss/_normalize.scss
+++ b/resources/scss/_normalize.scss
@@ -1,4 +1,5 @@
-// via [HTML5 Reset](http://html5reset.org)
+//// via [HTML5 Reset](http://html5reset.org)
+////
 * {
   background: transparent;
   border: 0;
@@ -8,9 +9,10 @@
   text-decoration: none;
   vertical-align: baseline;
 }
-//
+////
 
-// via [CSS Normalize](http://necolas.github.io/normalize.css)
+//// via [CSS Normalize](http://necolas.github.io/normalize.css)
+////
 article,
 aside,
 details,
@@ -33,7 +35,7 @@ body {
   -webkit-text-size-adjust: 100%;
   height: 100%;
 }
-//
+////
 
 body {
   margin: 0 auto;
@@ -81,11 +83,12 @@ pre {
   box-sizing: border-box;
 }
 
-// Viewport normalization for modern IE and future
-// via [Trent Walton](http://trentwalton.com/2013/01/16/windows-phone-8-viewport-fix)
+//// Viewport normalization for modern IE and future
+//// via [Trent Walton](http://trentwalton.com/2013/01/16/windows-phone-8-viewport-fix)
+////
 @-webkit-viewport { width: device-width; }
    @-moz-viewport { width: device-width; }
     @-ms-viewport { width: device-width; }
      @-o-viewport { width: device-width; }
         @viewport { width: device-width; }
-//
+////

--- a/resources/scss/block/_footnotes.scss
+++ b/resources/scss/block/_footnotes.scss
@@ -58,10 +58,6 @@
 
 .ancillary--endnotes + .footnotes {
   margin-top: 0;
-
-  @include min-width(l03) {
-    margin-top: -1em;
-  }
 }
 
 .reversefootnote {

--- a/resources/scss/block/_footnotes.scss
+++ b/resources/scss/block/_footnotes.scss
@@ -76,3 +76,17 @@
 .ancillary--endnotes + .footnotes {
   border-top: solid 1px;
 }
+
+// Inline body footnotes
+sup[id] {
+  margin: 0;
+  top: 0;
+}
+
+.footnote {
+  border: solid 1px;
+  border-radius: .125em;
+  font-weight: $weight-medium;
+  margin-right: .125em;
+  padding: 0 .25em;
+}

--- a/resources/scss/block/_image.scss
+++ b/resources/scss/block/_image.scss
@@ -58,6 +58,11 @@
   }
 }
 
+p + .image,
+p + .image--wide {
+  margin-top: 2em;
+}
+
 // Utility for right-aligned images
 .right {
   @include min-width(s04) {

--- a/resources/scss/block/_item.scss
+++ b/resources/scss/block/_item.scss
@@ -105,6 +105,10 @@
 .item--section-description {
   font-weight: $weight-light;
 
+  a {
+    padding-bottom: .0625em;
+  }
+
   h1 {
     font-weight: $weight-light;
   }

--- a/resources/scss/block/_project.scss
+++ b/resources/scss/block/_project.scss
@@ -173,4 +173,5 @@
 .project--satellite h1 {
   font-size: 1.25em;
   margin-top: auto;
+  line-height: 1.25;
 }

--- a/resources/scss/block/_project.scss
+++ b/resources/scss/block/_project.scss
@@ -32,7 +32,6 @@
   margin-top: 1em;
 
   .project-image {
-    border: solid 1px;
     height: 10em;
   }
 

--- a/resources/scss/container/_grid.scss
+++ b/resources/scss/container/_grid.scss
@@ -35,6 +35,11 @@
     flex-flow: row nowrap;
     max-width: none;
     width: calc(100% + 9em);
+
+    figcaption p {
+      margin-left: calc(50% + 1em);
+      width: calc(50% - 1em);
+    }
   }
 
   @include min-width(l03) {
@@ -63,11 +68,6 @@ p + .grid--wide {
   @include min-width(l01) {
     flex: 1 1 50%;
     margin-right: 1em;
-
-    figcaption p {
-      margin-left: calc(50% + 1em);
-      width: calc(50% - 1em);
-    }
   }
 }
 

--- a/resources/scss/container/_grid.scss
+++ b/resources/scss/container/_grid.scss
@@ -7,6 +7,10 @@
   @include min-width(l01) {
     flex-flow: row nowrap;
   }
+
+  p + {
+    margin-top: 2em;
+  }
 }
 
 .grid--wide {
@@ -39,6 +43,11 @@
   }
 }
 
+p + .grid,
+p + .grid--wide {
+  margin-top: 2em;
+}
+
 .grid figure + figure,
 .grid--wide figure + figure {
   margin-top: 1em;
@@ -61,7 +70,6 @@
     }
   }
 }
-
 
 .grid-figure--33 {
   margin: auto;

--- a/resources/scss/container/_grid.scss
+++ b/resources/scss/container/_grid.scss
@@ -110,7 +110,7 @@ p + .grid--wide {
   font-size: 1rem;
   justify-content: flex-start;
   list-style-type: none;
-  margin: 0 auto 1em;
+  margin: 1em auto;
   max-width: 45em;
 
   @include min-width(l03) {

--- a/resources/scss/helper/_functions.scss
+++ b/resources/scss/helper/_functions.scss
@@ -1,3 +1,4 @@
+
 @function c($value, $color-lightness: false) {
   $color: map-get($colors, $value);
   $color-hue: hue($color);

--- a/resources/scss/helper/_mixins.scss
+++ b/resources/scss/helper/_mixins.scss
@@ -92,10 +92,10 @@
 }
 
 // For randomly assigning shades to layers of the logo
-@mixin random-fill($start: 2, $end: 17) {
+@mixin random-fill($start: 2, $end: 17, $color: shade) {
   @for $i from $start through $end {
     svg :nth-child(#{$i}) {
-      fill: c(shade, random(80) + 12);
+      fill: c($color, random(80) + 12);
     }
   }
 }

--- a/resources/scss/helper/_mixins.scss
+++ b/resources/scss/helper/_mixins.scss
@@ -61,11 +61,11 @@
   }
 }
 
-@mixin a-underline($link: $red--trans20, $hover: $blue) {
-  border-bottom: solid 1px $link;
+@mixin a-underline($link: $red, $hover: $blue) {
+  border-bottom: solid 1.5px $link;
   &:hover,
   &:focus {
-    border-bottom: solid 1px $hover;
+    border-bottom: solid 1.5px $hover;
   }
 }
 

--- a/resources/scss/helper/_mixins.scss
+++ b/resources/scss/helper/_mixins.scss
@@ -62,10 +62,10 @@
 }
 
 @mixin a-underline($link: $red, $hover: $blue) {
-  border-bottom: solid 1.5px $link;
+  border-bottom: solid .08em $link;
   &:hover,
   &:focus {
-    border-bottom: solid 1.5px $hover;
+    border-bottom: solid .08em $hover;
   }
 }
 

--- a/resources/scss/helper/_variables.scss
+++ b/resources/scss/helper/_variables.scss
@@ -4,7 +4,7 @@ $colors: (
   violet: hsl(225, 35%, 45%),
   red: hsl(4, 60%, 42%),
   green: hsl(144, 50%, 35%),
-  shade: hsla(204, 10%, 12%, 1)
+  shade: hsl(204, 10%, 12%),
 );
 
 // Output colors
@@ -16,7 +16,7 @@ $pink: c(red, 88%);
 $green: c(green);
 
 // Output shades
-$black: c(shade);
+$black: c(shade, 12%);
 $gray00: c(shade, 18%);
 $gray01: c(shade, 24%);
 $gray02: c(shade, 32%);

--- a/resources/scss/helper/_variables.scss
+++ b/resources/scss/helper/_variables.scss
@@ -16,17 +16,17 @@ $pink: c(red, 88%);
 $green: c(green);
 
 // Output shades
-$black: c(shade, 12%);
-$gray00: c(shade, 18%);
-$gray01: c(shade, 24%);
-$gray02: c(shade, 32%);
-$gray03: c(shade, 40%);
-$gray04: c(shade, 72%);
-$gray05: c(shade, 80%);
-$gray06: c(shade, 88%);
-$gray07: c(shade, 92%);
+$black: c(shade);
 $white: c(shade, 95%);
-$whiter: c(shade, 97%);
+$gray00: scale-color($black, $lightness: 5%);
+$gray01: scale-color($black, $lightness: 10%);
+$gray02: scale-color($black, $lightness: 15%);
+$gray03: scale-color($black, $lightness: 20%);
+$gray04: scale-color($white, $lightness: -20%);
+$gray05: scale-color($white, $lightness: -15%);
+$gray06: scale-color($white, $lightness: -10%);
+$gray07: scale-color($white, $lightness: -5%);
+$whiter: scale-color($white, $lightness: 40%);
 
 // Output transparent colors and shades
 $blue--trans20: trans20($blue);

--- a/resources/scss/theme/_base.scss
+++ b/resources/scss/theme/_base.scss
@@ -8,7 +8,6 @@ $back--footer: $back--minus;
 $back--project: $gray06;
 $back--project-image: $gray07;
 $back--notes: $lightblue;
-$back--notes--inverse: $red--trans20;
 
 $fore--plus: $black;
 $fore--minus: $gray03;
@@ -23,7 +22,8 @@ $code-block--back: $gray02;
 $accent: $blue;
 $accent--trans: $blue--trans20;
 $accent--neutral: $gray04;
-$accent--notes: $accent--trans;
+$accent--inverse: $red;
+$accent--inverse--trans: $red--trans20;
 
 $link: $black;
 $link-underline: $red;
@@ -193,34 +193,7 @@ mark {
 }
 
 .ancillary--thanks {
-  background-color: $back--notes--inverse;
-}
-
-.footnotes,
-.ancillary--endnotes {
-  background-color: $back--notes;
-}
-
-.ancillary--endnotes + .footnotes,
-.footnotes li {
-  border-color: $accent--notes;
-}
-
-.footnotes ol li::before {
-  border-color: $accent--trans;
-  color: $fore--minus;
-}
-
-.reversefootnote {
-  border-color: $anchor;
-  color: $anchor;
-
-  &:hover,
-  &:focus {
-    background-color: $anchor-back--hover;
-    border-color: $anchor--hover;
-    color: $anchor--hover;
-  }
+  background-color: $accent--inverse--trans;
 }
 
 .hero figcaption {

--- a/resources/scss/theme/_base.scss
+++ b/resources/scss/theme/_base.scss
@@ -257,7 +257,7 @@ mark {
 }
 
 %page-pagination_color {
-  @include action-color($accent--inverse, $back--minus); // default
+  @include action-color($accent--inverse, $gray07); // default
 }
 
 .page-pagination--later {
@@ -265,7 +265,16 @@ mark {
 }
 
 .page-pagination--earlier {
-  @include action-color($accent, $back--minus);
+  @include action-color($accent, $gray07);
+}
+
+.credits {
+  background-color: $back--minus;
+  color: $fore;
+
+  a {
+    @include a-underline;
+  }
 }
 
 .micro .banner {

--- a/resources/scss/theme/_base.scss
+++ b/resources/scss/theme/_base.scss
@@ -83,19 +83,6 @@ blockquote a {
   @include a-underline;
 }
 
-sup[id] a {
-  background-color: $anchor-back;
-  border-color: $anchor;
-  color: $anchor;
-
-  &:hover,
-  &:focus {
-    background-color: $anchor-back--hover;
-    border-color: $anchor--hover;
-    color: $anchor--hover;
-  }
-}
-
 ul li::before {
   color: $accent--neutral;
 }
@@ -198,6 +185,19 @@ mark {
 
 .hero figcaption {
   background-color: $back--plus;
+}
+
+.footnote {
+  background-color: $anchor-back;
+  border-color: $anchor;
+  color: $anchor;
+
+  &:hover,
+  &:focus {
+    background-color: $anchor-back--hover;
+    border-color: $anchor--hover;
+    color: $anchor--hover;
+  }
 }
 
 .highlight {

--- a/resources/scss/theme/_base.scss
+++ b/resources/scss/theme/_base.scss
@@ -173,7 +173,7 @@ mark {
   color: $focus;
 
   a {
-    color: $link--action;
+    color: $focus-link;
     @include a-underline($link-underline, $focus-link--hover);
   }
 
@@ -217,8 +217,7 @@ mark {
   background-color: $back--project;
 }
 
-.project-image,
-.project--satellite .project-image {
+.project-image {
   background-color: $back--project-image;
   border-color: $back--minus;
 }

--- a/resources/scss/theme/_base.scss
+++ b/resources/scss/theme/_base.scss
@@ -242,6 +242,10 @@ mark {
 .project,
 .project--satellite {
   background-color: $back--project;
+
+  h1 a {
+    @include a-underline($trans01, $link--hover);
+  }
 }
 
 .project-image {

--- a/resources/scss/theme/_base.scss
+++ b/resources/scss/theme/_base.scss
@@ -1,3 +1,5 @@
+//// Theme definition
+////
 $back: $white;
 $fore: $gray01;
 
@@ -39,6 +41,7 @@ $anchor-back--hover: $red--trans20;
 $focus: $accent;
 $focus-link: $link--action;
 $focus-link--hover: $violet;
+////
 
 html {
   color: $fore;

--- a/resources/scss/theme/_base.scss
+++ b/resources/scss/theme/_base.scss
@@ -25,18 +25,20 @@ $accent--trans: $blue--trans20;
 $accent--neutral: $gray04;
 $accent--notes: $accent--trans;
 
-$focus: $accent;
-$focus-link--hover: $violet;
-
-$link: $red;
+$link: $black;
+$link-underline: $red;
 $link--hover: $blue;
 $link--active: $green;
-$link-underline: $red--trans20;
+$link--action: $red;
 
 $anchor: $blue;
 $anchor--hover: $red;
 $anchor-back: $blue--trans20;
 $anchor-back--hover: $red--trans20;
+
+$focus: $accent;
+$focus-link: $link--action;
+$focus-link--hover: $violet;
 
 html {
   color: $fore;
@@ -163,7 +165,7 @@ mark {
 }
 
 .action {
-  @include action-color($link, $fore--inverse);
+  @include action-color($link--action, $fore--inverse);
   @include a-borderless;
 }
 
@@ -171,7 +173,7 @@ mark {
   color: $focus;
 
   a {
-    color: $link;
+    color: $link--action;
     @include a-underline($link-underline, $focus-link--hover);
   }
 

--- a/resources/scss/theme/_dark.scss
+++ b/resources/scss/theme/_dark.scss
@@ -37,7 +37,7 @@ $anchor-back: $blue--trans20;
 $anchor-back--hover: $red--trans20;
 
 $focus: $accent;
-$focus-link: $link--action;
+$focus-link: $whiter;
 $focus-link--hover: $pink;
 
 html {
@@ -116,11 +116,15 @@ kbd > kbd {
   color: $fore--inverse;
 }
 
+.archive {
+  background-color: $back--plus;
+}
+
 .item--short {
-  background-color: $gray01;
+  background-color: $back;
 
   &:nth-child(2n) {
-    background-color: $gray02;
+    background-color: $back--minus;
   }
 
   h1 a {
@@ -182,6 +186,14 @@ figcaption {
   }
 }
 
+.hero figcaption {
+  background-color: $back--minus;
+
+  .edgeless & {
+    background-color: $back;
+  }
+}
+
 .footnotes,
 .ancillary--endnotes {
   color: $fore--inverse;
@@ -191,7 +203,7 @@ figcaption {
     color: $fore--inverse;
   }
 
-  a:not(.reversefootnote) {
+  a:not(.action):not(.reversefootnote) {
     @include a-underline;
     color: $fore--inverse;
 
@@ -214,12 +226,17 @@ figcaption {
   }
 }
 
-.project {
+.project,
+.project--satellite {
   background-color: $back--project;
 
   .edgeless & {
     background-color: $back--minus;
   }
+}
+
+.project-nav-action--satellite {
+  @include action-color($fore, $back);
 }
 
 .project-image {

--- a/resources/scss/theme/_dark.scss
+++ b/resources/scss/theme/_dark.scss
@@ -2,10 +2,10 @@ $back: $gray00;
 $fore: $gray07;
 
 $back--plus: $black;
-$back--minus: $gray02;
+$back--minus: $gray01;
 $back--inverse: $fore;
-$back--footer: $gray01;
-$back--project: $gray01;
+$back--footer: $gray02;
+$back--project: $gray02;
 $back--project-image: $gray03;
 $back--notes: $blue--trans20;
 $back--notes--inverse: $gray03;
@@ -235,10 +235,6 @@ figcaption {
 
 .page-footer {
   background-color: $back--footer;
-}
-
-.edgeless .page-footer {
-  background-color: $back--minus;
 }
 
 .screenshot img {

--- a/resources/scss/theme/_dark.scss
+++ b/resources/scss/theme/_dark.scss
@@ -1,3 +1,5 @@
+//// Theme definition
+////
 $back: $gray00;
 $fore: $gray07;
 
@@ -39,6 +41,7 @@ $anchor-back--hover: $red--trans20;
 $focus: $accent;
 $focus-link: $whiter;
 $focus-link--hover: $pink;
+////
 
 html {
   color: $fore;

--- a/resources/scss/theme/_dark.scss
+++ b/resources/scss/theme/_dark.scss
@@ -25,18 +25,20 @@ $accent--trans: $gray07--trans50;
 $accent--neutral: $gray05;
 $accent--notes: $gray03;
 
-$focus: $accent;
-$focus-link--hover: $pink;
-
-$link: $pink;
+$link: $whiter;
+$link-underline: $pink;
 $link--hover: $lightblue;
 $link--active: $green;
-$link-underline: $pink--trans50;
+$link--action: $red;
 
 $anchor: $lightblue;
 $anchor--hover: $pink;
 $anchor-back: $blue--trans20;
 $anchor-back--hover: $red--trans20;
+
+$focus: $accent;
+$focus-link: $link--action;
+$focus-link--hover: $pink;
 
 html {
   color: $fore;
@@ -120,6 +122,16 @@ kbd > kbd {
   &:nth-child(2n) {
     background-color: $gray02;
   }
+
+  h1 a {
+    @include a-underline($trans01, $lightblue);
+    color: $pink;
+
+    &:hover,
+    &:focus {
+      color: $lightblue;
+    }
+  }
 }
 
 .item-location a {
@@ -136,14 +148,14 @@ figcaption {
 }
 
 .action {
-  @include action-color($link, $back--inverse);
+  @include action-color($link--action, $back--inverse);
 }
 
 .focus {
   color: $focus;
 
   a {
-    color: $link;
+    color: $focus-link;
     @include a-underline($link-underline, $focus-link--hover);
   }
 

--- a/resources/scss/theme/_dark.scss
+++ b/resources/scss/theme/_dark.scss
@@ -233,6 +233,10 @@ figcaption {
   .edgeless & {
     background-color: $back--minus;
   }
+
+  h1 a {
+    @include a-underline($trans01, $link--hover);
+  }
 }
 
 .project-nav-action--satellite {

--- a/resources/scss/theme/_dark.scss
+++ b/resources/scss/theme/_dark.scss
@@ -63,19 +63,6 @@ h5 {
   color: $fore--minus;
 }
 
-sup[id] a {
-  background-color: $trans01;
-  border-color: $anchor;
-  color: $anchor;
-
-  &:hover,
-  &:focus {
-    background-color: $anchor-back--hover;
-    border-color: $anchor--hover;
-    color: $anchor--hover;
-  }
-}
-
 article a {
   color: $link;
 }
@@ -191,6 +178,19 @@ figcaption {
 
   .edgeless & {
     background-color: $back;
+  }
+}
+
+.footnote {
+  background-color: $trans01;
+  border-color: $anchor;
+  color: $anchor;
+
+  &:hover,
+  &:focus {
+    background-color: $anchor-back--hover;
+    border-color: $anchor--hover;
+    color: $anchor--hover;
   }
 }
 

--- a/resources/scss/theme/_dark.scss
+++ b/resources/scss/theme/_dark.scss
@@ -8,7 +8,6 @@ $back--footer: $gray02;
 $back--project: $gray02;
 $back--project-image: $gray03;
 $back--notes: $blue--trans20;
-$back--notes--inverse: $gray03;
 
 $fore--plus: $white;
 $fore--minus: $gray06;
@@ -23,7 +22,8 @@ $code-block--back: $whiter;
 $accent: $lightblue;
 $accent--trans: $gray07--trans50;
 $accent--neutral: $gray05;
-$accent--notes: $gray03;
+$accent--inverse: $pink;
+$accent--inverse--trans: $gray03;
 
 $link: $whiter;
 $link-underline: $pink;
@@ -175,33 +175,30 @@ figcaption {
 }
 
 .ancillary--thanks {
-  background-color: $back--notes--inverse;
+  background-color: $back;
+
+  .edgeless & {
+    background-color: $back--minus;
+  }
 }
 
 .footnotes,
 .ancillary--endnotes {
-  background-color: $back--notes;
-}
+  color: $fore--inverse;
 
-.ancillary--endnotes + .footnotes,
-.footnotes li {
-  border-color: $accent--notes;
-}
+  h1,
+  h2 {
+    color: $fore--inverse;
+  }
 
-.footnotes ol li::before {
-  border-color: $accent--trans;
-  color: $fore--minus;
-}
+  a:not(.reversefootnote) {
+    @include a-underline;
+    color: $fore--inverse;
 
-.reversefootnote {
-  border-color: $anchor;
-  color: $anchor;
-
-  &:hover,
-  &:focus {
-    background-color: $anchor-back--hover;
-    border-color: $anchor--hover;
-    color: $anchor--hover;
+    &:hover,
+    &:focus {
+      color: $blue;
+    }
   }
 }
 
@@ -219,10 +216,10 @@ figcaption {
 
 .project {
   background-color: $back--project;
-}
 
-.edgeless .project {
-  background-color: $back--minus;
+  .edgeless & {
+    background-color: $back--minus;
+  }
 }
 
 .project-image {

--- a/resources/scss/theme/_dark.scss
+++ b/resources/scss/theme/_dark.scss
@@ -64,7 +64,7 @@ h5 {
 }
 
 sup[id] a {
-  background-color: $anchor-back;
+  background-color: $trans01;
   border-color: $anchor;
   color: $anchor;
 

--- a/resources/scss/theme/_paper.scss
+++ b/resources/scss/theme/_paper.scss
@@ -57,10 +57,10 @@ $link--hover: $blue;
 $link--active: $green;
 $link--action: $red;
 
-$anchor: $blue;
-$anchor--hover: $red;
-$anchor-back: $blue--trans20;
-$anchor-back--hover: $red--trans20;
+$anchor: $accent;
+$anchor--hover: $accent--inverse;
+$anchor-back: $accent--trans;
+$anchor-back--hover: $accent--inverse--trans;
 
 $focus: $accent;
 $focus-link: $link;

--- a/resources/scss/theme/_paper.scss
+++ b/resources/scss/theme/_paper.scss
@@ -1,13 +1,13 @@
 //// Custom defined colors for this theme
 ////
 $beige_tomap: hsl(58, 40%, 92%);
-$black_tomap: hsl(0, 0%, 8%);
+$black_tomap: hsl(58, 10%, 12%);
 
 // add new colors to universal $colors map
 $colors: map-merge($colors, (beige: $beige_tomap));
 $colors: map-merge($colors, (black: $black_tomap));
 
-$black: c(black, 12%);
+$black: c(black);
 $gray00: c(black, 16%);
 $gray01: c(black, 21%);
 $gray02: c(black, 24%);

--- a/resources/scss/theme/_paper.scss
+++ b/resources/scss/theme/_paper.scss
@@ -1,6 +1,9 @@
+//// Custom defined colors for this theme
+////
 $beige_tomap: hsl(58, 40%, 92%);
 $black_tomap: hsl(0, 0%, 8%);
 
+// add new colors to universal $colors map
 $colors: map-merge($colors, (beige: $beige_tomap));
 $colors: map-merge($colors, (black: $black_tomap));
 
@@ -17,8 +20,10 @@ $white: c(beige, 96%);
 $whiter: c(beige, 98%);
 
 $tan: c(beige, 92%);
+////
 
-
+//// Theme definition
+////
 $back: $white;
 $fore: $gray01;
 
@@ -60,6 +65,7 @@ $anchor-back--hover: $red--trans20;
 $focus: $accent;
 $focus-link: $link;
 $focus-link--hover: $violet;
+////
 
 html {
   color: $fore;
@@ -263,6 +269,10 @@ mark {
 .project,
 .project--satellite {
   background-color: $back--project;
+
+  h1 a {
+    @include a-underline($trans01, $link--hover);
+  }
 }
 
 .project-image {

--- a/resources/scss/theme/_paper.scss
+++ b/resources/scss/theme/_paper.scss
@@ -1,3 +1,24 @@
+$beige_tomap: hsl(58, 40%, 92%);
+$black_tomap: hsl(0, 0%, 8%);
+
+$colors: map-merge($colors, (beige: $beige_tomap));
+$colors: map-merge($colors, (black: $black_tomap));
+
+$black: c(black, 8%);
+$gray00: c(black, 12%);
+$gray01: c(black, 16%);
+$gray02: c(black, 20%);
+$gray03: c(black, 24%);
+$gray04: c(black, 80%);
+$gray05: c(black, 84%);
+$gray06: c(black, 88%);
+$gray07: c(black, 92%);
+$white: c(beige, 96%);
+$whiter: c(beige, 98%);
+
+$tan: c(beige, 92%);
+
+
 $back: $white;
 $fore: $gray01;
 
@@ -7,7 +28,7 @@ $back--inverse: $fore;
 $back--footer: $back--minus;
 $back--project: $gray06;
 $back--project-image: $gray07;
-$back--notes: $lightblue;
+$back--notes: $tan;
 
 $fore--plus: $black;
 $fore--minus: $gray03;
@@ -19,11 +40,11 @@ $code--border: $gray05;
 $code-block--fore: $whiter;
 $code-block--back: $gray02;
 
-$accent: $blue;
-$accent--trans: $blue--trans20;
+$accent: $red;
+$accent--trans: $red--trans20;
 $accent--neutral: $gray04;
-$accent--inverse: $red;
-$accent--inverse--trans: $red--trans20;
+$accent--inverse: $blue;
+$accent--inverse--trans: $blue--trans20;
 
 $link: $black;
 $link-underline: $red;
@@ -37,7 +58,7 @@ $anchor-back: $blue--trans20;
 $anchor-back--hover: $red--trans20;
 
 $focus: $accent;
-$focus-link: $link--action;
+$focus-link: $link;
 $focus-link--hover: $violet;
 
 html {
@@ -180,7 +201,7 @@ mark {
 }
 
 .ancillary--thanks {
-  background-color: $accent--inverse--trans;
+  background-color: $back--minus;
 }
 
 .hero figcaption {
@@ -250,7 +271,7 @@ mark {
 }
 
 %page-pagination_color {
-  @include action-color($accent--inverse, $back--minus); // default
+  @include action-color($accent--inverse, $tan); // default
 }
 
 .page-pagination--later {
@@ -258,7 +279,7 @@ mark {
 }
 
 .page-pagination--earlier {
-  @include action-color($accent, $back--minus);
+  @include action-color($accent, $tan);
 }
 
 .micro .banner {

--- a/resources/scss/theme/_paper.scss
+++ b/resources/scss/theme/_paper.scss
@@ -7,19 +7,19 @@ $black_tomap: hsl(0, 0%, 8%);
 $colors: map-merge($colors, (beige: $beige_tomap));
 $colors: map-merge($colors, (black: $black_tomap));
 
-$black: c(black, 8%);
-$gray00: c(black, 12%);
-$gray01: c(black, 16%);
-$gray02: c(black, 20%);
-$gray03: c(black, 24%);
-$gray04: c(black, 80%);
-$gray05: c(black, 84%);
-$gray06: c(black, 88%);
-$gray07: c(black, 92%);
+$black: c(black, 12%);
+$gray00: c(black, 16%);
+$gray01: c(black, 21%);
+$gray02: c(black, 24%);
+$gray03: c(black, 30%);
+$gray04: c(black, 76%);
+$gray05: c(black, 81%);
+$gray06: c(black, 85%);
+$gray07: c(black, 90%);
 $white: c(beige, 96%);
 $whiter: c(beige, 98%);
 
-$tan: c(beige, 92%);
+$tan: c(beige, 93%);
 ////
 
 //// Theme definition
@@ -290,6 +290,19 @@ mark {
 
 .page-pagination--earlier {
   @include action-color($accent, $tan);
+}
+
+.credits {
+  background-color: $back--minus;
+  color: $fore;
+
+  a {
+    @include a-underline;
+  }
+}
+
+.banner-title {
+  @include random-fill(2, 17, black);
 }
 
 .micro .banner {

--- a/resources/scss/theme/_universal.scss
+++ b/resources/scss/theme/_universal.scss
@@ -1,5 +1,5 @@
 .skip {
-  @include action-color($red, $whiter);
+  @include action-color($whiter, $black);
 }
 
 .category {
@@ -81,7 +81,13 @@
   background-color: $gray07--trans90;
 
   h1 a {
-    @include a-underline($trans01, $blue--trans20);
+    @include a-underline($trans01, $blue);
+    color: $red;
+
+    &:hover,
+    &:focus {
+      color: $blue;
+    }
   }
 }
 

--- a/resources/scss/theme/_universal.scss
+++ b/resources/scss/theme/_universal.scss
@@ -145,15 +145,6 @@
   @include action-color($blue, $whiter);
 }
 
-.credits {
-  background-color: $gray06;
-  color: $black;
-
-  a {
-    @include a-underline;
-  }
-}
-
 .project-nav-action--url {
   @include action-color($red, $whiter);
 }

--- a/resources/scss/theme/_universal.scss
+++ b/resources/scss/theme/_universal.scss
@@ -154,33 +154,6 @@
   }
 }
 
-.footnotes,
-.ancillary--endnotes {
-  background-color: $lightblue;
-}
-
-.ancillary--endnotes + .footnotes,
-.footnotes li {
-  border-color: $blue--trans20;
-}
-
-.footnotes ol li::before {
-  border-color: $blue--trans20;
-  color: $gray03;
-}
-
-.reversefootnote {
-  border-color: $blue;
-  color: $blue;
-
-  &:hover,
-  &:focus {
-    background-color: $red--trans20;
-    border-color: $red;
-    color: $red;
-  }
-}
-
 .project-nav-action--url {
   @include action-color($red, $whiter);
 }
@@ -191,16 +164,4 @@
 
 .project-nav-action--satellite {
   @include action-color($gray02, $whiter);
-}
-
-%page-pagination_color {
-  @include action-color($red, $gray07); // default
-}
-
-.page-pagination--later {
-  @extend %page-pagination_color;
-}
-
-.page-pagination--earlier {
-  @include action-color($blue, $gray07);
 }

--- a/resources/scss/theme/_universal.scss
+++ b/resources/scss/theme/_universal.scss
@@ -154,6 +154,33 @@
   }
 }
 
+.footnotes,
+.ancillary--endnotes {
+  background-color: $lightblue;
+}
+
+.ancillary--endnotes + .footnotes,
+.footnotes li {
+  border-color: $blue--trans20;
+}
+
+.footnotes ol li::before {
+  border-color: $blue--trans20;
+  color: $gray03;
+}
+
+.reversefootnote {
+  border-color: $blue;
+  color: $blue;
+
+  &:hover,
+  &:focus {
+    background-color: $red--trans20;
+    border-color: $red;
+    color: $red;
+  }
+}
+
 .project-nav-action--url {
   @include action-color($red, $whiter);
 }


### PR DESCRIPTION
## Significant

- Use link colors with a red underline, black face (highest contrast item on the page, but less prominent than bright red links when reading)
- New paper-like, beige `paper` theme applied to a handful of older posts
- More accessible colors
- Shade scaling for `base`/`universal` theme

## Minor

- Rationalize dark theme colors (including darkening `.archive` index pages)
- Refactoring SCSS
- Greater top margins for images or `.grid` elements that follow paragraphs (leaving photos next to photos with tight `1em` margins)
- Support for super-wide `.hero` images on `.edgeless` theme (probably only use with SVG because of how heavy this could be with large images)
- Move more SCSS from `universal` back to `base` (for theming purposes)