### PR TITLE
Travis maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
-language: ruby
-rvm:
-  - 2.3.1
+language: node_js
+node_js:
+  - '4.4.2'
 
 cache:
   bundler: true
   directories:
     - node_modules
+
+before_install:
+  - rvm install 2.3.1
 
 install:
   - bundle install

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:jekyll": "npm-run-all dev:css dev:js 'dev:jekyll -- --profile'",
     "start": "npm-run-all --parallel serve:*",
     "dev": "npm-run-all dev:*",
-    "test": "htmlproofer ./_site --url-ignore \"/typekit.com/\"",
+    "test": "htmlproofer ./_site --url-ignore \"/typekit.com/\" --http-status-ignore \"0\"",
     "prod": "npm-run-all prod:*"
   },
   "repository": {


### PR DESCRIPTION
- Use node 4.4.2 as the basis for building
- htmlproofer: Ignore HTTP `0` status (not a real status) – was causing false positive results in builds, leading to “failed” builds in Travis